### PR TITLE
optional Settings:

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,12 @@
 ---------------------------------------------------------------------------------------------------
+Version: 0.5.7
+Date: 2021-11-01
+  Changes:
+    - Add German translation
+    - Restored vanilla TempStations settings as default.
+  Features:
+    - Add Option to apply changes to TempStations for personal Train only.
+---------------------------------------------------------------------------------------------------
 Version: 0.5.6
 Date: 2021-02-05
   Changes:

--- a/control.lua
+++ b/control.lua
@@ -43,10 +43,9 @@ local function mod_update_settings()
   global.config.switch_to_manual = (settings.global["tempstations-behaviour"].value == "switch-to-manual" and true or false)
   global.config.apply_custom_conditions = (settings.global["tempstations-behaviour"].value == "apply-custom-conditions" and true or false)
   global.config.remove_all = settings.global["tempstations-removetemps"].value
-  
   global.config.search_radius = tonumber(settings.global["tempstations-searchradius"].value)
   global.config.render_target = settings.global["tempstations-rendertarget"].value
-  
+  global.config.personal_train_only = settings.global["tempstations-personaltrainonly"].value
   global.config.openschedule = settings.global["tempstations-openschedule"].value
 end
 script.on_event({defines.events.on_runtime_mod_setting_changed}, mod_update_settings) 

--- a/info.json
+++ b/info.json
@@ -1,6 +1,6 @@
 {
     "name": "TemporaryStations",
-    "version": "0.5.6",
+    "version": "0.5.7",
     "title": "Temporary Stations (Wait Conditions and Personal Trains)",
     "author": "Sparkinium",
     "contact": "",

--- a/locale/de/de.cfg
+++ b/locale/de/de.cfg
@@ -1,0 +1,55 @@
+[mod-setting-name]
+tempstations-searchradius=Suchradius
+tempstations-rendertarget=Zeige Zielpunkt für persönlichen Zug 
+tempstations-behaviour=Verhalten bei Ankunft
+tempstations-personaltrainonly=Ändere temporäre Haltestelle nur für persönlichen Zug
+tempstations-removetemps=Entferne temporäre Haltestelle
+tempstations-openschedule=Öffne Zugfahrplan beim einsteigen in persönlichen Zug
+
+[string-mod-setting]
+tempstations-behaviour-switch-to-manual=Schalte auf manuellen Modus
+tempstations-behaviour-apply-custom-conditions=Verwende angepasste Einstellungen
+
+[mod-setting-description]
+tempstations-rendertarget=
+tempstations-searchradius=Suchradius für näheste Gleise
+tempstations-removetemps=Entferne jede weiter temporäre Haltestelle vom Fahrplan
+tempstations-openschedule=
+
+[controls]
+temp-call-a-train=Rufe persönlichen Zug
+temp-open-schedule=Öffne persönlichen Zug Fahrplan
+temp-locate=Finde persönlichen Zug
+
+[tempstations]
+frame_title_main=Temporäre Haltestelle
+frame_title_personal=Persönlicher Zug
+shortcut_name=Rufe persönlichen Zug / Öffne Konfiguration
+
+button_clear=Lösche persönlichen Zug
+button_select=Setze persönlichen Zug
+button_waiting=Warte..
+
+label_commands=Zusätzliche Befehle:
+label_manual=Bei Ankunft: Wechsle zu manuellen Modus
+label_custom=Apply custom wait conditions
+label_remove_all1=Entferne alle temporäre
+label_remove_all2=Haltestelle vom Fahrplan
+label_remove_other1=Entferne andere temporäre
+label_remove_other2=Haltestelle vom Fahrplan
+
+label_instruction_1=__1__1. Klicke auf 'Setze persönlichen Zug'__2__
+label_instruction_2=__1__2. Klicke auf eine von deinen Lokomotiven__2__
+label_instruction_3=__1__3. Nutze den Shortcut um deinen persönlichen Zug zu rufen__2__
+
+
+[notifications]
+setting-personal-train=__1__ Dein persönlichen Zug wurde gesetzt auf Zug-Kennung: __2__
+clearing-personal-train=__1__ Dein persönlichen Zug wurde gelöscht.
+personal-train-not-found=__1__ Dein persönlichen Zug konnte nicht gefunden werden.
+copied-schedule=__1__ Kopiere die Wartebedingungen der ersten Station. Diese sind nun die Standardbedingungen für temporäre Haltestellen.
+
+[commands]
+setdefaultschedule=Nutze diesen Befehl während du eine Lokomotive anschaust/auswählst. Die Wartebedingungen der ersten Station werden die Standardbedingungen für temporäre Haltestellen.
+setpersonaltrain=Nutze diesen Befehl während du eine Lokomotive anschaust/auswählst um sie als deinen persönlichen Zug zu setzen. Nutze diesen Befehl während du nichts anschaust/auswählst um deinen persönlichen Zug zu löschen.
+tempconfig=Nutze diesen Befehl um das Konfigurationsfenster zu öffnen. Nützlich wenn schon ein persönlichen Zug gesetzt ist.

--- a/locale/en/en.cfg
+++ b/locale/en/en.cfg
@@ -2,6 +2,7 @@
 tempstations-searchradius=Search Radius
 tempstations-rendertarget=Render Personal Train Target
 tempstations-behaviour=Behaviour upon arrival
+tempstations-personaltrainonly=Change Temporary Stations only for Personal Train
 tempstations-removetemps=Remove Temporary Stations
 tempstations-openschedule=Open schedule upon entering your train
 

--- a/migrations/0.5.7.lua
+++ b/migrations/0.5.7.lua
@@ -1,0 +1,1 @@
+global.config.personal_train_only = settings.global["tempstations-personaltrainonly"].value

--- a/scripts/temp-core.lua
+++ b/scripts/temp-core.lua
@@ -7,7 +7,7 @@ global.config = global.config or {
   
   remove_all = true,
   
-  default_conditions = {{type="inactivity", compare_type="and", ticks=300}, {type="passenger_present", compare_type="and"}},
+  default_conditions = {{type="inactivity", compare_type="and", ticks=300}},
   
   search_radius = 20,
   render_target = true,
@@ -70,7 +70,6 @@ local train_state_strings = {
   [defines.train_state.manual_control_stop] = "MANUAL_CONTROL_STOP",
   [defines.train_state.manual_control]      = "MANUAL_CONTROL",
 }
-
 
 function print_train_state(new_state, old_state)
   local message = "TrainState: "
@@ -206,6 +205,19 @@ end
 temp_core.train_state_changed = function(event)
   if global.blacklisted_trains[event.train.id] then
     return
+  end
+
+  -- check if modify temp-station apply only for personal-train
+  if global.config.personal_train_only == true then
+    local is_personal_train = false
+    for _, train in pairs(global.personal_train) do
+      if train == event.train then
+        is_personal_train = true
+      end
+    end
+    if is_personal_train == false then
+      return
+    end
   end
   
   -- check for temporary stations and modify the wait condition  

--- a/settings.lua
+++ b/settings.lua
@@ -8,6 +8,12 @@ data:extend({
     },
     {
         type = "bool-setting",
+        name = "tempstations-personaltrainonly",
+        setting_type = "runtime-global",
+        default_value = true
+    },
+    {
+        type = "bool-setting",
         name = "tempstations-removetemps",
         setting_type = "runtime-global",
         default_value = true


### PR DESCRIPTION
- apply the temporary station magic only on the personal train, every other train will behave like vanilla
- restore the vanilla behave as default,
- add German translation